### PR TITLE
Centralize errors for well-formed but unrecognized opcodes

### DIFF
--- a/eightdad/core/vm.py
+++ b/eightdad/core/vm.py
@@ -104,6 +104,7 @@ class Chip8VirtualMachine:
         self.tick_length = 1.0 / ticks_per_second
 
         self.instruction_parser = Chip8Instruction()
+        self.instruction_unhandled = False
 
     @property
     def delay_timer(self):
@@ -154,7 +155,7 @@ class Chip8VirtualMachine:
             self.memory[self.i_register + 2] = ones
 
         else:
-            raise NotImplementedError("Instruction not yet supported")
+            self.instruction_unhandled = True
 
         self.program_increment += 1
 
@@ -182,7 +183,7 @@ class Chip8VirtualMachine:
                 self.program_counter += self.v_registers[0]
 
         else:
-            raise NotImplementedError("Unsupported instruction")
+            self.instruction_unhandled = True
 
     def handle_ixkk(self) -> None:
         x = self.instruction_parser.x
@@ -207,7 +208,7 @@ class Chip8VirtualMachine:
             self.v_registers[x] = randrange(0, 0xFF) & kk
 
         else:
-            raise NotImplementedError("Unsupported instruction")
+            self.instruction_unhandled = True
 
         self.program_increment += 1
 
@@ -285,10 +286,18 @@ class Chip8VirtualMachine:
             if self.instruction_parser.lo_byte == 0xEE:
                 self.stack_return()
             else:
-                raise NotImplementedError("Instruction not supported")
+                self.instruction_unhandled = True
 
         else:
-            raise NotImplementedError("Instruction not yet supported")
+            self.instruction_unhandled = True
+
+        if self.instruction_unhandled:
+            raise ValueError(
+                f"Unrecognized instruction 0x"
+                f"{hex(self.memory[self.program_counter])}"
+                f"{hex(self.memory[self.program_counter+1])}"
+                f"at address 0x{hex(self.program_counter)}"
+            )
 
         # advance by any amount we need to
         self.program_counter += self.program_increment

--- a/tests/core/vm/interpreter/test_unhandled_instruction.py
+++ b/tests/core/vm/interpreter/test_unhandled_instruction.py
@@ -1,0 +1,23 @@
+import pytest
+from eightdad.core import Chip8VirtualMachine
+from tests.util import load_and_execute_instruction
+
+
+@pytest.mark.parametrize(
+    "patterned_unrecognizeable_instruction",
+    (
+        0xFFFF,
+        0xE1FF,
+        0x5001,
+    )
+)
+def test_valuerror_on_unhandled_instruction(
+        patterned_unrecognizeable_instruction
+):
+    """Unhandled instructions raise ValueError"""
+    vm = Chip8VirtualMachine()
+    with pytest.raises(ValueError):
+        load_and_execute_instruction(
+            vm,
+            patterned_unrecognizeable_instruction
+        )


### PR DESCRIPTION
Closes #21 